### PR TITLE
CVE-2016-7067 fix: CSRF token now required for POST

### DIFF
--- a/lib/monitjs.js
+++ b/lib/monitjs.js
@@ -3,6 +3,7 @@ var http = require('http');
 var async = require('async');
 var request = require('request');
 var xml2js = require('xml2js');
+var urllib = require('url');
 
 // Get Monit Status Information
 Monit.prototype.status = function(service, callback) {
@@ -38,18 +39,50 @@ Monit.prototype.restart = function(service, callback) {
 };
 
 // operations on _doaction POST endpoint. Note: monit doesn't return any data after a successful action.
-function doAction (url, service, action, callback) {
-  request({url: url, method:'POST', body: 'service=' + service + '&action=' + action}, function(err, response, body){
-    if(err) return callback(err);
+function doAction(url, service, action, callback) {
+  // query status to acquire CSRF token, without which the POST request will fail
+  // (from monit v5.20, https://bitbucket.org/tildeslash/monit/commits/c6ec3820)
+  var cookiejar = request.jar(),
+      up = urllib.parse(url),
+      statusurl = up.protocol + '//' + up.auth + '@' + up.host + '/_status?format=xml'
+  request({url: statusurl, jar: cookiejar}, function(err, response, body) {
+    if (err) return callback(err);
     // Workaround monit 'service unavailable' errors
-    if(response.statusCode === 503) {
-      return setTimeout(function(){
+    if (response.statusCode === 503) {
+      return setTimeout(function() {
         return doAction(url, service, action, callback);
       }, 1000);
     }
-    if(response.statusCode !== 200) return callback({statusCode: response.statusCode , error: body});
-    return callback(err, body);
-  });  
+    if (response.statusCode !== 200) {
+      return callback({statusCode: response.statusCode , error: body});
+    }
+
+    // get CSRF from cookie
+    var cookies = cookiejar.get({url: statusurl}), auth = "";
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = cookies[i];
+      if (cookie.name == "securitytoken") {
+        auth = "&securitytoken=" + cookies[0].value;
+        break;
+      }
+    }
+
+    // do the actual monit action request (POST + CSRF token)
+    var body = 'service=' + service + '&action=' + action + auth;
+    request({url: url, method: 'POST', body: body, jar: cookiejar}, function(err, response, body) {
+      if (err) return callback(err);
+      // Workaround monit 'service unavailable' errors
+      if (response.statusCode === 503) {
+        return setTimeout(function() {
+          return doAction(url, service, action, callback);
+        }, 1000);
+      }
+      if(response.statusCode !== 200) {
+        return callback({statusCode: response.statusCode , error: body});
+      }
+      return callback(err, body);
+    });
+  });
 };
 
 // operations on the _status endpoint


### PR DESCRIPTION
Action requests (POST) require a CSRF token in both cookie and query,
since Monit v5.20
(https://bitbucket.org/tildeslash/monit/commits/c6ec3820).

We acquire the CSRF token from cookie by doing a simple GET status
request first, then use that token for the POST action in both cookie
and query (form body).